### PR TITLE
Preserve Formatting of existing files

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ def get_github_client(access_token: str) -> github.Github:
 
 def load_configurations() -> dict:
     with open("package_manager.yml") as file:
-        config = yaml.load(file, Loader=yaml.FullLoader)
+        config = ruamel.yaml.load(file, Loader=ruamel.yaml.RoundTripLoader, preserve_quotes=True)        
     return config
 
 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import yaml
 import hashlib
 import time
 import argparse
+import ruamel.yaml
 
 
 def set_branch_name() -> str:
@@ -42,7 +43,7 @@ def update_packages(
 ) -> None:
     try:
         packages_content = repo.get_contents("packages.yml")
-        packages = yaml.load(packages_content.decoded_content, Loader=yaml.FullLoader)
+        packages = ruamel.yaml.load(packages_content.decoded_content, Loader=ruamel.yaml.RoundTripLoader, preserve_quotes=True)
 
         for package in packages["packages"]:
             name = package["package"]
@@ -52,7 +53,7 @@ def update_packages(
         repo.update_file(
             path=packages_content.path,
             message="Updating package dependendcies",
-            content=yaml.dump(packages, encoding="utf-8", default_flow_style=False),
+            content=ruamel.yaml.dump(packages, Dumper=ruamel.yaml.RoundTripDumper),
             sha=packages_content.sha,
             branch=branch_name,
         )
@@ -64,13 +65,14 @@ def update_project(
     repo: github.Repository.Repository, branch_name: str, config: str
 ) -> None:
     project_content = repo.get_contents("dbt_project.yml")
-    project = yaml.load(project_content.decoded_content, Loader=yaml.FullLoader)
+    project = ruamel.yaml.load(project_content.decoded_content, Loader=ruamel.yaml.RoundTripLoader, preserve_quotes=True)
+
     project["require-dbt-version"] = config["require-dbt-version"]
 
     repo.update_file(
         path=project_content.path,
         message="Updating require-dbt-version",
-        content=yaml.dump(project, encoding="utf-8", default_flow_style=False),
+        content=ruamel.yaml.dump(project, Dumper=ruamel.yaml.RoundTripDumper),
         sha=project_content.sha,
         branch=branch_name,
     )

--- a/package_manager.yml
+++ b/package_manager.yml
@@ -1,6 +1,6 @@
 repositories:
   transform:
-    - dbt_hubspot
+    - dbt_linkedin
   source:
     # - dbt_hubspot_source
     - dbt_linkedin_source

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 PyGithub==1.53
-pyyaml==5.3.1
 mypy==0.790
 argparse==1.4.0
 ruamel.yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyGithub==1.53
 pyyaml==5.3.1
 mypy==0.790
 argparse==1.4.0
+ruamel.yaml


### PR DESCRIPTION
Hey Dylan -
I played around with trying to preserve the formatting of the original `dbt_project.yml` files and came across this stack overflow article about using ruamel.yaml instead of pyyaml.  For reference [here](https://yaml.readthedocs.io/en/latest/overview.html) is the ruamel.yml documentation and [here](https://stackoverflow.com/questions/20805418/pyyaml-dump-format) is the stack overflow article.


Here is the difference in PRs:
Using master: https://github.com/fivetran/dbt_linkedin_source/pull/6/files

Using existing branch: https://github.com/fivetran/dbt_linkedin_source/pull/12/files


Also, I'm not 100% sure on this, but we may be able to remove the `pyyaml==5.3.1` requirement.