### PR TITLE
functionality for bumping package version and requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -25,7 +25,9 @@ def get_github_client(access_token: str) -> github.Github:
 
 def load_configurations() -> dict:
     with open("package_manager.yml") as file:
-        config = ruamel.yaml.load(file, Loader=ruamel.yaml.RoundTripLoader, preserve_quotes=True)        
+        config = ruamel.yaml.load(
+            file, Loader=ruamel.yaml.RoundTripLoader, preserve_quotes=True
+        )
     return config
 
 
@@ -43,7 +45,11 @@ def update_packages(
 ) -> None:
     try:
         packages_content = repo.get_contents("packages.yml")
-        packages = ruamel.yaml.load(packages_content.decoded_content, Loader=ruamel.yaml.RoundTripLoader, preserve_quotes=True)
+        packages = ruamel.yaml.load(
+            packages_content.decoded_content,
+            Loader=ruamel.yaml.RoundTripLoader,
+            preserve_quotes=True,
+        )
 
         for package in packages["packages"]:
             if "package" in package:
@@ -70,9 +76,31 @@ def update_project(
     repo: github.Repository.Repository, branch_name: str, config: str
 ) -> None:
     project_content = repo.get_contents("dbt_project.yml")
-    project = ruamel.yaml.load(project_content.decoded_content, Loader=ruamel.yaml.RoundTripLoader, preserve_quotes=True)
+    project = ruamel.yaml.load(
+        project_content.decoded_content,
+        Loader=ruamel.yaml.RoundTripLoader,
+        preserve_quotes=True,
+    )
 
     project["require-dbt-version"] = config["require-dbt-version"]
+
+    current_version = project["version"]
+    bump_type = config["version-bump-type"]
+
+    current_version_split = current_version.split(".")
+
+    if bump_type == "patch":
+        current_version_split[2] = str(int(current_version_split[2]) + 1)
+    elif bump_type == "minor":
+        current_version_split[1] = str(int(current_version_split[1]) + 1)
+        current_version_split[2] = "0"
+    elif bump_type == "major":
+        current_version_split[0] = str(int(current_version_split[0]) + 1)
+        current_version_split[1] = "0"
+        current_version_split[2] = "0"
+
+    new_version = ".".join(current_version_split)
+    project["version"] = new_version
 
     repo.update_file(
         path=project_content.path,
@@ -88,10 +116,13 @@ def update_requirements(
 ) -> None:
     try:
         requirements_content = repo.get_contents("integration_tests/requirements.txt")
+        new_content = ""
+        for requirement in config["requirements"]:
+            new_content += f"{requirement['name']}=={requirement['version']}\n"
         repo.update_file(
             path=requirements_content.path,
             message="Updating dbt version in requirements.txt",
-            content="dbt==" + str(config["ci-dbt-version"]),
+            content=new_content,
             sha=requirements_content.sha,
             branch=branch_name,
         )
@@ -99,7 +130,7 @@ def update_requirements(
         repo.create_file(
             path="integration_tests/requirements.txt",
             message="Updating dbt version in requirements.txt",
-            content="dbt==" + str(config["ci-dbt-version"]),
+            content=new_content,
             branch=branch_name,
         )
 

--- a/package_manager.yml
+++ b/package_manager.yml
@@ -2,15 +2,21 @@ repositories:
   transform:
     - dbt_linkedin
   source:
-    # - dbt_hubspot_source
     - dbt_linkedin_source
   utils:
     - dbt_fivetran_utils
 
-require-dbt-version: [">=0.18.0", "<0.19.0"]
+require-dbt-version: [">=0.20.0"]
 
 packages:
-  fishtown-analytics/dbt_utils: [">=0.6.0", "<0.7.0"]
-  "https://github.com/fivetran/dbt_fivetran_utils.git": master 
+  fivetran/fivetran_utils: [">=0.2.0", "<0.3.0"]
 
-ci-dbt-version: 0.18.0
+requirements:
+  - name: dbt
+    version: 0.20.0
+  - name: dbt-spark
+    version: 0.20.0
+  - name: dbt-spark[PyHive]
+    version: 0.20.0
+
+version-bump-type: minor # major, minor or patch

--- a/package_manager.yml
+++ b/package_manager.yml
@@ -1,15 +1,89 @@
 repositories:
   transform:
-    - dbt_linkedin
+    # - dbt_ad_reporting
+    # - dbt_asana
+    # - dbt_facebook_ads
+    # - dbt_facebook_ads_creative_history
+    # - dbt_fivetran_log
+    # - dbt_fivetran_utils
+    # - dbt_github
+    # - dbt_google_ads
+    # - dbt_greenhouse
+    # - dbt_hubspot
+    # - dbt_intercom
+    # - dbt_iterable
+    # - dbt_jira
+    # - dbt_klaviyo 
+    # - dbt_lever
+    # - dbt_linkedin
+    # - dbt_mailchimp
+    # - dbt_marketo
+    # - dbt_microsoft_ads
+    # - dbt_mixpanel
+    # - dbt_netsuite
+    # - dbt_pardot
+    # - dbt_pinterest
+    # - dbt_quickbooks
+    # - dbt_salesforce
+    # - dbt_salesforce_formula_utils
+    - dbt_snapchat_ads
+    # - dbt_shopify
+    # - dbt_stripe
+    # - dbt_twitter
+    # - dbt_zendesk
   source:
-    - dbt_linkedin_source
+    # - dbt_asana_source
+    # - dbt_facebook_ads_source
+    # - dbt_github_source
+    # - dbt_google_ads_source
+    # - dbt_greenhouse_source
+    # - dbt_hubspot_source
+    # - dbt_intercom_source
+    # - dbt_iterable_source
+    # - dbt_jira_source
+    # - dbt_klaviyo_source
+    # - dbt_lever_source
+    # - dbt_linkedin_source
+    # - dbt_marketo_source
+    # - dbt_microsoft_ads_source
+    # - dbt_netsuite_source
+    # - dbt_pardot_source
+    # - dbt_pinterest_source
+    # - dbt_quickbooks_source
+    # - dbt_salesforce_source
+    # - dbt_shopify_source
+    # - dbt_stripe_source
+    # - dbt_twitter_source
+    # - dbt_zendesk_source
   utils:
-    - dbt_fivetran_utils
+    # - dbt_fivetran_utils
+  other:
+    # - dbt_facebook_ads_creative_history
+    # - dbt_ad_reporting
 
 require-dbt-version: [">=0.20.0"]
 
 packages:
   fivetran/fivetran_utils: [">=0.2.0", "<0.3.0"]
+  fivetran/google_ads_source: [">=0.3.0", "<0.4.0"]
+  fivetran/linkedin_source: [">=0.4.0", "<0.5.0"]
+  fivetran/microsoft_ads_source: [">=0.3.0", "<0.4.0"]
+  fivetran/pinterest_source: [">=0.4.0", "<0.5.0"]
+  fivetran/twitter_ads_source: [">=0.3.0", "<0.4.0"]
+  fivetran/facebook_ads_source: [">=0.3.0", "<0.4.0"]
+  fivetran/github_source: [">=0.3.0", "<0.4.0"]
+  fivetran/greenhouse_source: [">=0.3.0", "<0.4.0"]
+  fivetran/intercom_source: [">=0.3.0", "<0.4.0"]
+  fivetran/zendesk_source: [">=0.4.0", "<0.5.0"]
+  fivetran/stripe_source: [">=0.4.0", "<0.5.0"]
+  fivetran/shopify_source: [">=0.5.0", "<0.6.0"]
+  fivetran/salesforce_source: [">=0.3.0", "<0.4.0"]
+  fivetran/pardot_source: [">=0.3.0", "<0.4.0"]
+  fivetran/netsuite_source: [">=0.3.0", "<0.4.0"]
+  fivetran/lever_source: [">=0.2.0", "<0.3.0"]
+  fivetran/klaviyo_source: [">=0.2.0", "<0.3.0"]
+  fivetran/jira_source: [">=0.3.0", "<0.4.0"]
+  fivetran/snapchat_ads_source: [">=0.2.0", "<0.3.0"]
 
 requirements:
   - name: dbt


### PR DESCRIPTION
For the changes to dbt version 0.20.0, we've needed to add two features to this service:
- Be able to automatically do a major, minor, or patch to the `version` key in `dbt_project.yml`
- Be able to automatically update _multiple_ python packages in `requirements.txt`.

This PR adds both those features. An example PR created by the new state can be seen [here](https://github.com/fivetran/dbt_linkedin_source/pull/30/files).