### PR TITLE
Changes for v1.0.0 migrations

### DIFF
--- a/main.py
+++ b/main.py
@@ -67,7 +67,9 @@ def update_packages(
         repo.update_file(
             path=packages_content.path,
             message="[ci skip] Updating package dependendcies",
-            content=ruamel.yaml.dump(packages, Dumper=ruamel.yaml.RoundTripDumper),
+            content=ruamel.yaml.dump(
+                packages, Dumper=ruamel.yaml.RoundTripDumper, width=10000
+            ),
             sha=packages_content.sha,
             branch=branch_name,
         )
@@ -117,7 +119,9 @@ def update_project(
     repo.update_file(
         path=project_content.path,
         message="Updating dbt_project.yml",
-        content=ruamel.yaml.dump(project, Dumper=ruamel.yaml.RoundTripDumper),
+        content=ruamel.yaml.dump(
+            project, Dumper=ruamel.yaml.RoundTripDumper, width=10000
+        ),
         sha=project_content.sha,
         branch=branch_name,
     )
@@ -143,7 +147,9 @@ def update_integration_project(
     repo.update_file(
         path=project_content.path,
         message="[ci skip] Updating integration_tests/dbt_project.yml",
-        content=ruamel.yaml.dump(project, Dumper=ruamel.yaml.RoundTripDumper),
+        content=ruamel.yaml.dump(
+            project, Dumper=ruamel.yaml.RoundTripDumper, width=10000
+        ),
         sha=project_content.sha,
         branch=branch_name,
     )

--- a/main.py
+++ b/main.py
@@ -66,7 +66,7 @@ def update_packages(
 
         repo.update_file(
             path=packages_content.path,
-            message="Updating package dependendcies",
+            message="[ci skip] Updating package dependendcies",
             content=ruamel.yaml.dump(packages, Dumper=ruamel.yaml.RoundTripDumper),
             sha=packages_content.sha,
             branch=branch_name,
@@ -105,9 +105,44 @@ def update_project(
     new_version = ".".join(current_version_split)
     project["version"] = new_version
 
+    # v1.0.0 migrations
+
+    clean_targets = project.get("clean-targets", None)
+    if clean_targets:
+        project["clean-targets"].append("dbt_packages")
+
+    project.pop("source-paths", None)
+    project.pop("data-paths", None)
+
     repo.update_file(
         path=project_content.path,
-        message="Updating require-dbt-version",
+        message="[ci skip] Updating dbt_project.yml",
+        content=ruamel.yaml.dump(project, Dumper=ruamel.yaml.RoundTripDumper),
+        sha=project_content.sha,
+        branch=branch_name,
+    )
+
+
+def update_integration_project(
+    repo: github.Repository.Repository, branch_name: str, config: str
+) -> None:
+    project_content = repo.get_contents("integration_tests/dbt_project.yml")
+    project = ruamel.yaml.load(
+        project_content.decoded_content,
+        Loader=ruamel.yaml.RoundTripLoader,
+        preserve_quotes=True,
+    )
+
+    clean_targets = project.get("clean-targets", None)
+    if clean_targets:
+        project["clean-targets"].append("dbt_packages")
+
+    project.pop("source-paths", None)
+    project.pop("data-paths", None)
+
+    repo.update_file(
+        path=project_content.path,
+        message="[ci skip] Updating integration_tests/dbt_project.yml",
         content=ruamel.yaml.dump(project, Dumper=ruamel.yaml.RoundTripDumper),
         sha=project_content.sha,
         branch=branch_name,
@@ -124,7 +159,7 @@ def update_requirements(
             new_content += f"{requirement['name']}=={requirement['version']}\n"
         repo.update_file(
             path=requirements_content.path,
-            message="Updating dbt version in requirements.txt",
+            message="[ci skip] Updating dbt version in requirements.txt",
             content=new_content,
             sha=requirements_content.sha,
             branch=branch_name,
@@ -132,8 +167,73 @@ def update_requirements(
     except github.GithubException:
         repo.create_file(
             path="integration_tests/requirements.txt",
-            message="Updating dbt version in requirements.txt",
+            message="[ci skip] Updating dbt version in requirements.txt",
             content=new_content,
+            branch=branch_name,
+        )
+
+
+def update_data_folder_to_seed(
+    repo: github.Repository.Repository, branch_name: str
+) -> None:
+    try:
+        seed_files = repo.get_contents("data")
+    except:
+        seed_files = None
+    if seed_files:
+        for file in seed_files:
+            repo.create_file(
+                path=file.path.replace("data/", "seeds/"),
+                message="[ci skip] Moving folder",
+                content=file.decoded_content,
+                branch=branch_name,
+            )
+            repo.delete_file(
+                path=file.path,
+                message="[ci skip] Moving folder",
+                sha=file.sha,
+                branch=branch_name,
+            )
+    try:
+        integration_seed_files = repo.get_contents("integration_tests/data")
+    except:
+        integration_seed_files = None
+    if integration_seed_files:
+        for file in integration_seed_files:
+            repo.create_file(
+                path=file.path.replace("data/", "seeds/"),
+                message="[ci skip] Moving folder",
+                content=file.decoded_content,
+                branch=branch_name,
+            )
+            repo.delete_file(
+                path=file.path,
+                message="[ci skip] Moving folder",
+                sha=file.sha,
+                branch=branch_name,
+            )
+
+
+def add_dbt_packages_to_gitnore(
+    repo: github.Repository.Repository, branch_name: str
+) -> None:
+    try:
+        gitignore_content = repo.get_contents(".gitignore")
+        gitignore = gitignore_content.decoded_content.decode("utf-8")
+        gitignore += "\n"
+        gitignore += "dbt_packages/"
+        repo.update_file(
+            path=gitignore_content.path,
+            message="[ci skip] Adding dbt_packages to .gitignore",
+            content=gitignore,
+            sha=gitignore_content.sha,
+            branch=branch_name,
+        )
+    except github.GithubException:
+        repo.create_file(
+            path=".gitignore",
+            message="[ci skip] Adding dbt_packages to .gitignore",
+            content="dbt_packages/",
             branch=branch_name,
         )
 
@@ -181,6 +281,8 @@ def main():
         update_packages(repo, branch_name, config)
         update_project(repo, branch_name, config)
         update_requirements(repo, branch_name, config)
+        add_dbt_packages_to_gitnore(repo, branch_name)
+        update_data_folder_to_seed(repo, branch_name)
         open_pull_request(repo, branch_name, default_branch)
 
 

--- a/main.py
+++ b/main.py
@@ -75,7 +75,7 @@ def update_packages(
         print("'packages.yml' not found in repo.")
 
 
-def update_version(
+def update_project(
     repo: github.Repository.Repository, branch_name: str, config: str
 ) -> None:
     project_content = repo.get_contents("dbt_project.yml")
@@ -103,25 +103,6 @@ def update_version(
     new_version = ".".join(current_version_split)
     project["version"] = new_version
 
-    repo.update_file(
-        path=project_content.path,
-        message="Updating version in dbt_project.yml",
-        content=ruamel.yaml.dump(project, Dumper=ruamel.yaml.RoundTripDumper),
-        sha=project_content.sha,
-        branch=branch_name,
-    )
-
-
-def update_project(
-    repo: github.Repository.Repository, branch_name: str, config: str
-) -> None:
-    project_content = repo.get_contents("dbt_project.yml")
-    project = ruamel.yaml.load(
-        project_content.decoded_content,
-        Loader=ruamel.yaml.RoundTripLoader,
-        preserve_quotes=True,
-    )
-
     project["require-dbt-version"] = config["require-dbt-version"]
 
     # v1.0.0 migrations
@@ -135,7 +116,7 @@ def update_project(
 
     repo.update_file(
         path=project_content.path,
-        message="[ci skip] Updating dbt_project.yml",
+        message="Updating dbt_project.yml",
         content=ruamel.yaml.dump(project, Dumper=ruamel.yaml.RoundTripDumper),
         sha=project_content.sha,
         branch=branch_name,
@@ -298,11 +279,10 @@ def main():
     for repo_name in config["repositories"][args.repo_type]:
         repo, default_branch = setup_repo(client, repo_name, branch_name)
         update_packages(repo, branch_name, config)
-        update_project(repo, branch_name, config)
         update_requirements(repo, branch_name, config)
         add_dbt_packages_to_gitnore(repo, branch_name)
         update_data_folder_to_seed(repo, branch_name)
-        update_version(repo, branch_name, config)
+        update_project(repo, branch_name, config)
         open_pull_request(repo, branch_name, default_branch)
 
 

--- a/package_manager.yml
+++ b/package_manager.yml
@@ -26,7 +26,7 @@ repositories:
     # - dbt_quickbooks
     # - dbt_salesforce
     # - dbt_salesforce_formula_utils
-    - dbt_snapchat_ads
+    # - dbt_snapchat_ads
     # - dbt_shopify
     # - dbt_stripe
     # - dbt_twitter
@@ -43,7 +43,7 @@ repositories:
     # - dbt_jira_source
     # - dbt_klaviyo_source
     # - dbt_lever_source
-    # - dbt_linkedin_source
+    - dbt_linkedin_source
     # - dbt_marketo_source
     # - dbt_microsoft_ads_source
     # - dbt_netsuite_source
@@ -61,7 +61,7 @@ repositories:
     # - dbt_facebook_ads_creative_history
     # - dbt_ad_reporting
 
-require-dbt-version: [">=0.20.0"]
+require-dbt-version: [">=0.21.0", "<1.1.0"]
 
 packages:
   fivetran/fivetran_utils: [">=0.2.0", "<0.3.0"]
@@ -86,11 +86,17 @@ packages:
   fivetran/snapchat_ads_source: [">=0.2.0", "<0.3.0"]
 
 requirements:
-  - name: dbt
-    version: 0.20.0
+  - name: dbt-snowflake
+    version: 1.0.0
+  - name: dbt-bigquery
+    version: 1.0.0
+  - name: dbt-redshift
+    version: 1.0.0
+  - name: dbt-postgres
+    version: 1.0.0
   - name: dbt-spark
-    version: 0.20.0
+    version: 1.0.0
   - name: dbt-spark[PyHive]
-    version: 0.20.0
+    version: 1.0.0
 
 version-bump-type: minor # major, minor or patch


### PR DESCRIPTION
This PR aims to achieve the following changes:

* Update `data` folders to `seeds` in packages **(for v1.0.0)**
* Updates commit messages so that CI doesn't run on each commit
* Remove `data-paths` and `source-paths` lines in dbt-project.yml if present **(for v1.0.0)**
* Add `dbt_packages` to `clean-targets` and `.gitignore` **(for v1.0.0)**
* Removes the `dbt` requirement and changes to the data-warehouse specific packages, i.e. `dbt-bigquery` **(for v1.0.0)**

Before using this to upgrade packages, we will need to cut a new release of Fivetran Utils that (1) uses the new version of dbt Utils and (2) has the necessary v1.0.0 changes it in. 